### PR TITLE
Fix error when schema is null (disconnected backup and restore)

### DIFF
--- a/Signum.Engine/Connection/SqlConnector.cs
+++ b/Signum.Engine/Connection/SqlConnector.cs
@@ -42,7 +42,8 @@ namespace Signum.Engine
             this.ParameterBuilder = new SqlParameterBuilder();
 
             this.Version = version;
-            if (version >= SqlServerVersion.SqlServer2008)
+            // In disconnected scenarios schema can be null, this must be checked.
+            if (version >= SqlServerVersion.SqlServer2008 && schema != null)
             {
                 var s = schema.Settings;
 


### PR DESCRIPTION
In disconnected scenarios during backup and restore schema can be null, this must be checked
