### PR TITLE
Determine WeekNumber in database based on CultureInfo settings

### DIFF
--- a/Signum.Engine/Linq/DbExpressions.Sql.cs
+++ b/Signum.Engine/Linq/DbExpressions.Sql.cs
@@ -628,6 +628,7 @@ namespace Signum.Engine.Linq
         second,
         millisecond,
         dayofyear,
+        iso_week
     }
 
 

--- a/Signum.Engine/Linq/ExpressionVisitor/DbExpressionNominator.cs
+++ b/Signum.Engine/Linq/ExpressionVisitor/DbExpressionNominator.cs
@@ -12,6 +12,7 @@ using System.Collections;
 using System.Collections.ObjectModel;
 using Signum.Engine.Maps;
 using System.Data;
+using System.Globalization;
 using Signum.Entities.Reflection;
 using Microsoft.SqlServer.Types;
 using Microsoft.SqlServer.Server;
@@ -1095,7 +1096,13 @@ namespace Signum.Engine.Linq
                 case "DateTimeExtensions.YearsTo": return TryDatePartTo(new SqlEnumExpression(SqlEnums.year), m.GetArgument("start"), m.GetArgument("end"));
                 case "DateTimeExtensions.MonthsTo": return TryDatePartTo(new SqlEnumExpression(SqlEnums.month), m.GetArgument("start"), m.GetArgument("end"));
 
-                case "DateTimeExtensions.WeekNumber": return TrySqlFunction(null, SqlFunction.DATEPART, m.Type, new SqlEnumExpression(SqlEnums.week), m.Arguments.Single());
+                case "DateTimeExtensions.WeekNumber":
+                {
+                    if (CultureInfo.CurrentCulture.DateTimeFormat.CalendarWeekRule == CalendarWeekRule.FirstFourDayWeek)
+                        return TrySqlFunction(null, SqlFunction.DATEPART, m.Type, new SqlEnumExpression(SqlEnums.iso_week), m.Arguments.Single());
+
+                    return TrySqlFunction(null, SqlFunction.DATEPART, m.Type, new SqlEnumExpression(SqlEnums.week), m.Arguments.Single());
+                }
 
                 case "Math.Sign": return TrySqlFunction(null, SqlFunction.SIGN, m.Type, m.GetArgument("value"));
                 case "Math.Abs": return TrySqlFunction(null, SqlFunction.ABS, m.Type, m.GetArgument("value"));


### PR DESCRIPTION
My SQL Server 2012 database disregards the CultureInfo settings when calculating the WeekNumber. It always uses the U.S. English method in which weekday 1 is Sunday and week 1 starts on January 1st. This commit European style weeknumber calculation by making the framework use Datepart ISO_WEEK when the CultureInfo CalendarWeekRule is the FirstFourDayWeek. Monday is the first day of the week. 