### PR TITLE
Enable ScrollBar when visible

### DIFF
--- a/Signum.Windows/Controls/AutoCompleteTextBox.xaml.cs
+++ b/Signum.Windows/Controls/AutoCompleteTextBox.xaml.cs
@@ -330,8 +330,12 @@ namespace Signum.Windows
             }
             else if (pop.IsMouseOver)
             {
-                ReleaseMouseCapture();
-                Commit(CloseReason.ClickList);
+                var sb = lstBox.Child<ScrollBar>(WhereFlags.VisualTree);
+                if (!sb.IsMouseOver)
+                {
+                    ReleaseMouseCapture();
+                    Commit(CloseReason.ClickList);
+                }
             }
 
         }
@@ -436,4 +440,5 @@ namespace Signum.Windows
     }
 
     public delegate void ClosedEventHandler(object sender, CloseEventArgs e);
+
 }


### PR DESCRIPTION
Making use of the scrollbar of the listbox with Autocomplete results was not possible. This fix restores navigation function of scrollbar.