### PR TITLE
Develop

### DIFF
--- a/Signum.Entities/Basics/Exception.cs
+++ b/Signum.Entities/Basics/Exception.cs
@@ -142,7 +142,7 @@ namespace Signum.Entities.Basics
 
         public DateTime DateLimit
         {
-            get { return DateTime.Today.AddDays(-DeleteLogsWithMoreThan); }
+            get { return TimeZoneManager.Now.Date.AddDays(-DeleteLogsWithMoreThan); }
         }
 
         public int ChunkSize { get; set; } = 1000;

--- a/Signum.Windows/Controls/DateTimePicker.cs
+++ b/Signum.Windows/Controls/DateTimePicker.cs
@@ -157,6 +157,8 @@ namespace Signum.Windows
 
         void monthCalendar_SelectedDatesChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
         {
+            BindingExpression b = textBox.GetBindingExpression(TextBox.TextProperty);
+            b.UpdateSource();
             if (!avoidClose)
                 pickerBase.IsDropDownOpen = false;
         }


### PR DESCRIPTION
Commit 6e2345f has been merged last month already. Don't know why it appears again. Please ignore it.

Commit 5630008 fixes InvalidOperationException "Attempt to use a non-Utc date in the database" when you use the Calendar control to select a date in the DateTimePicker using TimeZoneMode.Utc.
