### PR TITLE
HashSet / Entity comparer

### DIFF
--- a/Signum.Engine/Engine/Saver.cs
+++ b/Signum.Engine/Engine/Saver.cs
@@ -44,9 +44,9 @@ namespace Signum.Engine
                     if (ident != null)
                         schema.OnPreSaving(ident, ref graphModified);
                 });
-
-                HashSet<Entity> wasNew = modifiables.OfType<Entity>().Where(a=>a.IsNew).ToHashSet();
-                HashSet<Entity> wasSelfModified = modifiables.OfType<Entity>().Where(a => a.Modified == ModifiedState.SelfModified).ToHashSet();
+                
+                HashSet<Entity> wasNew = modifiables.OfType<Entity>().Where(a=>a.IsNew).ToHashSet(ReferenceEqualityComparer<Entity>.Default);
+                HashSet<Entity> wasSelfModified = modifiables.OfType<Entity>().Where(a => a.Modified == ModifiedState.SelfModified).ToHashSet(ReferenceEqualityComparer<Entity>.Default);
 
                 log.Switch("Integrity");
 


### PR DESCRIPTION
SavedEventArgs.WasNew and SavedEventArgs.WasSelfModified were always false.