### PR TITLE
SearchControlLoaded: workaround for Edge bug in scrollTo method

### DIFF
--- a/Signum.React/Scripts/Lines/EntityLine.tsx
+++ b/Signum.React/Scripts/Lines/EntityLine.tsx
@@ -180,7 +180,7 @@ export class EntityLine extends EntityBase<EntityLineProps, EntityLineState> {
 
         const str =
             s.renderItem ? s.renderItem :
-            s.currentItem && s.currentItem.item && s.autoComplete ? s.autoComplete.renderItem(s.currentItem.item) :
+            s.currentItem && s.currentItem.item && s.autoComplete ? s.autoComplete.renderItem(s.currentItem) :
                     getToString(value);
 
         if (s.ctx.readOnly)

--- a/Signum.React/Scripts/SearchControl/SearchControlLoaded.tsx
+++ b/Signum.React/Scripts/SearchControl/SearchControlLoaded.tsx
@@ -187,7 +187,8 @@ export default class SearchControlLoaded extends React.Component<SearchControlLo
         if (fo.pagination.mode == "Paginate")
             fo.pagination.currentPage = 1;
 
-        this.containerDiv && this.containerDiv.scrollTo({ top: 0 });
+        if (this.containerDiv)
+            this.containerDiv.scrollTop = 0;
 
         this.doSearch().done();
     };
@@ -268,7 +269,8 @@ export default class SearchControlLoaded extends React.Component<SearchControlLo
 
         if (this.props.findOptions.pagination.mode != "All") {
 
-            this.containerDiv && this.containerDiv.scrollTo({ top: 0 });
+            if (this.containerDiv)
+                this.containerDiv.scrollTop = 0;
 
             this.doSearch().done();
         }
@@ -363,7 +365,7 @@ export default class SearchControlLoaded extends React.Component<SearchControlLo
             if (this.containerDiv.scrollTop > table.clientHeight) {
                 //var translate = "translate(0,0)";
                 //this.thead!.style.transform = translate;
-                this.containerDiv.scrollTo({ top: 0 });
+                this.containerDiv.scrollTop = 0;
                 this.containerDiv.style.overflowY = "hidden";
                 setTimeout(() => {
                     this.containerDiv!.style.overflowY = null;


### PR DESCRIPTION
Edge browser has a confirmed bug with the scrollTo method (https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15534521/) that caused an error on every search