### PR TITLE
Fixing FieldEnum.ToString()

### DIFF
--- a/Signum.Engine/Schema/Schema.Basics.cs
+++ b/Signum.Engine/Schema/Schema.Basics.cs
@@ -804,7 +804,7 @@ namespace Signum.Engine.Maps
 
         public override string ToString()
         {
-            return "{0} -> {1} {4} ({2})".FormatWith(
+            return "{0} -> {1} {3} ({2})".FormatWith(
                 Name,
                 "-",
                 IsLite ? "Lite" : "",


### PR DESCRIPTION
Fixing string format in FieldEnum.ToString()