### PR TITLE
Fix for Tabs.tsx activeEventKeytypes // string[]

### DIFF
--- a/Signum.React/Scripts/Components/Tabs.tsx
+++ b/Signum.React/Scripts/Components/Tabs.tsx
@@ -73,7 +73,7 @@ function getDefaultEventKey(props: UncontrolledTabsProps) {
 
 
 interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
-  activeEventKey: string | number | undefined;
+  activeEventKey: string | string[] | number | undefined;
   toggle: (eventKey: string | number) => void;
   hideOnly?: boolean;
   pills?: boolean;


### PR DESCRIPTION
Two times testing, one time deploying.