### PR TITLE
When using Postgres in docker/linux the version numbering is a little…

### DIFF
--- a/Signum.Engine/Connection/PostgreSqlConnector.cs
+++ b/Signum.Engine/Connection/PostgreSqlConnector.cs
@@ -37,7 +37,7 @@ namespace Signum.Engine
 
                         var version = (string)result.Rows[0]["server_version"]!;
 
-                        return new Version(version);
+                        return new Version(version.TryBefore("(") ?? version);
                     }
                 }
             });


### PR DESCRIPTION
… bit different

for example: 12.1 (Debian 12.1-1.pgdg100+1)