### PR TITLE
fix Assembly.BuildTimeUTC

### DIFF
--- a/Signum.Utilities/Reflection/ReflectionTools.cs
+++ b/Signum.Utilities/Reflection/ReflectionTools.cs
@@ -843,18 +843,20 @@ namespace Signum.Utilities.Reflection
         
         public static DateTime BuildTimeUTC(this Assembly assembly)
         {
-            const int peHeaderOffset = 60;
-            const int linkerTimestampOffset = 8;
-            byte[] bytes = new byte[2048];
-            using (FileStream file = new FileStream(assembly.Location, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-            {
-                file.Read(bytes, 0, bytes.Length);
-            }
-            int headerPos = BitConverter.ToInt32(bytes, peHeaderOffset);
-            int secondsSince1970 = BitConverter.ToInt32(bytes, headerPos + linkerTimestampOffset);
-            DateTime dt = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            DateTime dateTimeUTC = dt.AddSeconds(secondsSince1970);
-            return dateTimeUTC;
+            //const int peHeaderOffset = 60;
+            //const int linkerTimestampOffset = 8;
+            //byte[] bytes = new byte[2048];
+            //using (FileStream file = new FileStream(assembly.Location, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            //{
+            //    file.Read(bytes, 0, bytes.Length);
+            //}
+            //int headerPos = BitConverter.ToInt32(bytes, peHeaderOffset);
+            //int secondsSince1970 = BitConverter.ToInt32(bytes, headerPos + linkerTimestampOffset);
+            //DateTime dt = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            //DateTime dateTimeUTC = dt.AddSeconds(secondsSince1970);
+            //return dateTimeUTC;
+
+            return new FileInfo(assembly.Location).LastWriteTime.ToUniversalTime();
         }
     }
 }


### PR DESCRIPTION
Previous method was working for .Net Core 1.0, but stopped working after .Net Core 1.1 release(gives random years in 1900-2020 range).
With this change the method returns the last modification date for the assembly (the last time the file was writen into, not the creation date, so if copied on publishing it gives the right date) in UTC.