### PR TITLE
Property route parse full

### DIFF
--- a/Signum.React/Scripts/Reflection.ts
+++ b/Signum.React/Scripts/Reflection.ts
@@ -1360,7 +1360,11 @@ export class PropertyRoute {
   }
 
   static parseFull(fullPropertyRoute: string): PropertyRoute {
-    return PropertyRoute.parse(fullPropertyRoute.after("(").before(")."), fullPropertyRoute.after(")."));
+    const endPseudoTypeIndex = fullPropertyRoute.indexOf(")");
+    let propertyString = fullPropertyRoute.substr(endPseudoTypeIndex + 1);
+    if (propertyString.startsWith("."))
+      propertyString = propertyString.substr(1);
+    return PropertyRoute.parse(fullPropertyRoute.substring(1, endPseudoTypeIndex), propertyString);
   }
 
   static parse(rootType: PseudoType, propertyString: string): PropertyRoute {


### PR DESCRIPTION
Fix error in Search Control with property routes like: (MyType)[MyMixin].MyProperty where there's no ")." separating PseudoType and PropertyRoute strings