### PR TITLE
Introducing Manual refresh mode feature for UserQuery as well as its state in SCL

### DIFF
--- a/Signum.Entities/DynamicQuery/Requests.cs
+++ b/Signum.Entities/DynamicQuery/Requests.cs
@@ -67,6 +67,13 @@ namespace Signum.Entities.DynamicQuery
     }
 
     [DescriptionOptions(DescriptionOptions.Members), InTypeScript(true)]
+    public enum RefreshMode
+    {
+        Auto,
+        Manual
+    }
+
+    [DescriptionOptions(DescriptionOptions.Members), InTypeScript(true)]
     public enum SystemTimeMode
     {
         AsOf,

--- a/Signum.React/Scripts/SearchControl/PinnedFilterBuilder.tsx
+++ b/Signum.React/Scripts/SearchControl/PinnedFilterBuilder.tsx
@@ -10,10 +10,12 @@ import "./FilterBuilder.css"
 import { createFilterValueControl, MultiValue } from './FilterBuilder';
 import { SearchMessage } from '../Signum.Entities';
 import { classes } from '../Globals';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 interface PinnedFilterBuilderProps {
   filterOptions: FilterOptionParsed[];
   onFiltersChanged?: (filters: FilterOptionParsed[]) => void;
+  onSearchClick?: (ev: React.MouseEvent<any> | undefined) => void;
   extraSmall?: boolean;
 }
 export default function PinnedFilterBuilder(p: PinnedFilterBuilderProps) {
@@ -26,15 +28,22 @@ export default function PinnedFilterBuilder(p: PinnedFilterBuilderProps) {
     return null;
 
   return (
-    <div className={classes("row", p.extraSmall ? "" : "mt-3 mb-3")}>
-      {
-        allPinned
-          .groupBy(a => (a.pinned!.column ?? 0).toString())
-          .orderBy(gr => parseInt(gr.key))
-          .map(gr => <div className="col-sm-3" key={gr.key}>
-            {gr.elements.orderBy(a => a.pinned!.row).map((f, i) => <div key={i}>{renderValue(f)}</div>)}
-          </div>)
-      }
+    <div onKeyUp={handleFiltersKeyUp }>
+      <div className={classes("row", p.extraSmall ? "" : "mt-3 mb-3")}>
+        {
+          allPinned
+            .groupBy(a => (a.pinned!.column ?? 0).toString())
+            .orderBy(gr => parseInt(gr.key))
+            .map(gr => <div className="col-sm-3" key={gr.key}>
+              {gr.elements.orderBy(a => a.pinned!.row).map((f, i) => <div key={i}>{renderValue(f)}</div>)}
+            </div>)
+        }
+      </div>
+      {p.onSearchClick &&
+        <button className={classes("sf-query-button sf-search btn btn-primary")} onClick={p.onSearchClick} title="Enter">
+          <FontAwesomeIcon icon={"search"} />&nbsp;{SearchMessage.Search.niceToString()}
+        </button>}
+
     </div>
   );
 
@@ -89,6 +98,16 @@ export default function PinnedFilterBuilder(p: PinnedFilterBuilderProps) {
       p.onFiltersChanged && p.onFiltersChanged(p.filterOptions);
     }
   }
+
+  function handleFiltersKeyUp(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (p.onSearchClick && e.keyCode == 13) {
+      debugger;
+      setTimeout(() => {
+        p.onSearchClick!(undefined);
+      }, 200);
+    }
+  }
+
 }
 
 function getAllPinned(filterOptions: FilterOptionParsed[]): FilterOptionParsed[] {

--- a/Signum.React/Scripts/SearchControl/PinnedFilterBuilder.tsx
+++ b/Signum.React/Scripts/SearchControl/PinnedFilterBuilder.tsx
@@ -15,7 +15,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 interface PinnedFilterBuilderProps {
   filterOptions: FilterOptionParsed[];
   onFiltersChanged?: (filters: FilterOptionParsed[]) => void;
-  onSearchClick?: (ev: React.MouseEvent<any> | undefined) => void;
+  onSearch?: () => void;
+  showSearchButton?: boolean;
   extraSmall?: boolean;
 }
 export default function PinnedFilterBuilder(p: PinnedFilterBuilderProps) {
@@ -39,8 +40,8 @@ export default function PinnedFilterBuilder(p: PinnedFilterBuilderProps) {
             </div>)
         }
       </div>
-      {p.onSearchClick &&
-        <button className={classes("sf-query-button sf-search btn btn-primary")} onClick={p.onSearchClick} title="Enter">
+      {p.showSearchButton &&
+        <button className={classes("sf-query-button sf-search btn btn-primary")} onClick={() => p.onSearch && p.onSearch()} title="Enter">
           <FontAwesomeIcon icon={"search"} />&nbsp;{SearchMessage.Search.niceToString()}
         </button>}
 
@@ -84,6 +85,7 @@ export default function PinnedFilterBuilder(p: PinnedFilterBuilderProps) {
 
 
   function handleValueChange(f: FilterOptionParsed) {
+
     if (isFilterGroupOptionParsed(f) || f.token && f.token.filterType == "String") {
 
       if (timeoutWriteText.current)
@@ -100,10 +102,9 @@ export default function PinnedFilterBuilder(p: PinnedFilterBuilderProps) {
   }
 
   function handleFiltersKeyUp(e: React.KeyboardEvent<HTMLDivElement>) {
-    if (p.onSearchClick && e.keyCode == 13) {
-      debugger;
+    if (p.onSearch && e.keyCode == 13) {
       setTimeout(() => {
-        p.onSearchClick!(undefined);
+        p.onSearch!();
       }, 200);
     }
   }

--- a/Signum.React/Scripts/SearchControl/SearchControl.tsx
+++ b/Signum.React/Scripts/SearchControl/SearchControl.tsx
@@ -11,6 +11,7 @@ import { Property } from 'csstype';
 import "./Search.css"
 import { ButtonBarElement, StyleContext } from '../TypeContext';
 import { useForceUpdate, usePrevious, useStateWithPromise } from '../Hooks'
+import { RefreshMode } from '../Signum.Entities.DynamicQuery';
 
 export interface SimpleFilterBuilderProps {
   findOptions: FindOptions;
@@ -45,7 +46,7 @@ export interface SearchControlProps {
   create?: boolean;
   view?: boolean | "InPlace";
   largeToolbarButtons?: boolean;
-  defaultAvoidAutoRefresh?: boolean;
+  defaultRefreshMode?: RefreshMode;
   avoidChangeUrl?: boolean;
   throwIfNotFindable?: boolean;
   refreshKey?: any;
@@ -199,7 +200,7 @@ const SearchControl = React.forwardRef(function SearchControl(p: SearchControlPr
         showBarExtension={p.showBarExtension != null ? p.showBarExtension : true}
         showBarExtensionOption={p.showBarExtensionOption}
         largeToolbarButtons={p.largeToolbarButtons != null ? p.largeToolbarButtons : false}
-        defaultAvoidAutoRefresh={p.defaultAvoidAutoRefresh != null ? p.defaultAvoidAutoRefresh : false}
+        defaultRefreshMode={p.defaultRefreshMode ?? 'Auto'}
         avoidChangeUrl={p.avoidChangeUrl != null ? p.avoidChangeUrl : true}
         refreshKey={p.refreshKey}
         extraOptions={p.extraOptions}

--- a/Signum.React/Scripts/SearchControl/SearchControl.tsx
+++ b/Signum.React/Scripts/SearchControl/SearchControl.tsx
@@ -45,7 +45,7 @@ export interface SearchControlProps {
   create?: boolean;
   view?: boolean | "InPlace";
   largeToolbarButtons?: boolean;
-  avoidAutoRefresh?: boolean;
+  defaultAvoidAutoRefresh?: boolean;
   avoidChangeUrl?: boolean;
   throwIfNotFindable?: boolean;
   refreshKey?: any;
@@ -199,7 +199,7 @@ const SearchControl = React.forwardRef(function SearchControl(p: SearchControlPr
         showBarExtension={p.showBarExtension != null ? p.showBarExtension : true}
         showBarExtensionOption={p.showBarExtensionOption}
         largeToolbarButtons={p.largeToolbarButtons != null ? p.largeToolbarButtons : false}
-        avoidAutoRefresh={p.avoidAutoRefresh != null ? p.avoidAutoRefresh : false}
+        defaultAvoidAutoRefresh={p.defaultAvoidAutoRefresh != null ? p.defaultAvoidAutoRefresh : false}
         avoidChangeUrl={p.avoidChangeUrl != null ? p.avoidChangeUrl : true}
         refreshKey={p.refreshKey}
         extraOptions={p.extraOptions}

--- a/Signum.React/Scripts/SearchControl/SearchControlLoaded.tsx
+++ b/Signum.React/Scripts/SearchControl/SearchControlLoaded.tsx
@@ -419,21 +419,11 @@ export default class SearchControlLoaded extends React.Component<SearchControlLo
               onHeightChanged={this.handleHeightChanged}
               showPinnedFiltersOptions={false}
               showPinnedFiltersOptionsButton={true}
-              /> :
-                sfb ? <div className="simple-filter-builder">{sfb}</div> :
-                  <AutoFocus disabled={!this.props.enableAutoFocus}>
-                    <PinnedFilterBuilder
-                      filterOptions={fo.filterOptions}
-                      onFiltersChanged={this.handlePinnedFilterChanged} />
-                  </AutoFocus>
-            }
+            /> :
+              sfb ? <div className="simple-filter-builder">{sfb}</div> : this.renderPinnedFilters()}
           </div>
         }
-        {p.showHeader == "PinnedFilters" && <AutoFocus disabled={!this.props.enableAutoFocus}>
-          <PinnedFilterBuilder
-            filterOptions={fo.filterOptions}
-            onFiltersChanged={this.handlePinnedFilterChanged} extraSmall={true} />
-        </AutoFocus>}
+        {p.showHeader == "PinnedFilters" && this.renderPinnedFilters(true)}
         {p.showHeader == true && this.renderToolBar()}
         {p.showHeader == true && <MultipliedMessage findOptions={fo} mainType={this.entityColumn().type} />}
         {p.showHeader == true && fo.groupResults && <GroupByMessage findOptions={fo} mainType={this.entityColumn().type} />}
@@ -465,8 +455,8 @@ export default class SearchControlLoaded extends React.Component<SearchControlLo
   // TOOLBAR
 
 
-  handleSearchClick = (ev: React.MouseEvent<any>) => {
-    ev.preventDefault();
+  handleSearchClick = (ev: React.MouseEvent<any> | undefined) => {
+    ev && ev.preventDefault();
 
     this.doSearchPage1();
 
@@ -1379,6 +1369,20 @@ export default class SearchControlLoaded extends React.Component<SearchControlLo
     });
   }
 
+  renderPinnedFilters(extraSmall: boolean = false): React.ReactNode {
+
+    const fo = this.props.findOptions;
+
+    return <AutoFocus disabled={!this.props.enableAutoFocus}>
+      <PinnedFilterBuilder
+        filterOptions={fo.filterOptions}
+        onFiltersChanged={this.props.avoidAutoRefresh ? undefined : this.handlePinnedFilterChanged}
+        onSearchClick={this.props.avoidAutoRefresh ? this.handleSearchClick : undefined}
+        extraSmall={extraSmall}
+      />
+    </AutoFocus>
+  }
+  
   handleOnNavigated = (lite: Lite<Entity>) => {
 
     if (this.props.onNavigated)

--- a/Signum.React/Scripts/SearchControl/SearchModal.tsx
+++ b/Signum.React/Scripts/SearchControl/SearchModal.tsx
@@ -92,13 +92,13 @@ function SearchModal(p: SearchModalProps) {
           okPressed.current = true;
           setShow(false);
         } else {
-          if (!scl.props.avoidAutoRefresh)
+          if (!scl.state.avoidAutoRefresh)
             scl.doSearch(true);
         }
       }).done();
 
     } else {
-      if (!scl.props.avoidAutoRefresh)
+      if (!scl.state.avoidAutoRefresh)
         scl.doSearch(true);
     }
   }

--- a/Signum.React/Scripts/SearchControl/SearchModal.tsx
+++ b/Signum.React/Scripts/SearchControl/SearchModal.tsx
@@ -92,13 +92,13 @@ function SearchModal(p: SearchModalProps) {
           okPressed.current = true;
           setShow(false);
         } else {
-          if (!scl.state.avoidAutoRefresh)
+          if (scl.state.refreshMode == 'Auto')
             scl.doSearch(true);
         }
       }).done();
 
     } else {
-      if (!scl.state.avoidAutoRefresh)
+      if (scl.state.refreshMode == 'Auto')
         scl.doSearch(true);
     }
   }

--- a/Signum.React/Scripts/SearchControl/SearchModal.tsx
+++ b/Signum.React/Scripts/SearchControl/SearchModal.tsx
@@ -91,16 +91,12 @@ function SearchModal(p: SearchModalProps) {
           selectedRows.current = [{ entity: toLite(e), columns: [] }];
           okPressed.current = true;
           setShow(false);
-        } else {
-          if (scl.state.refreshMode == 'Auto')
+        } else 
             scl.doSearch(true);
-        }
       }).done();
 
-    } else {
-      if (scl.state.refreshMode == 'Auto')
+    } else 
         scl.doSearch(true);
-    }
   }
 
   function onResize() {

--- a/Signum.React/Scripts/Signum.Entities.DynamicQuery.ts
+++ b/Signum.React/Scripts/Signum.Entities.DynamicQuery.ts
@@ -119,6 +119,11 @@ export module QueryTokenMessage {
   export const Distinct = new MessageKey("QueryTokenMessage", "Distinct");
 }
 
+export const RefreshMode = new EnumType<RefreshMode>("RefreshMode");
+export type RefreshMode =
+  "Auto" |
+  "Manual";
+
 export const RoundingType = new EnumType<RoundingType>("RoundingType");
 export type RoundingType =
   "Floor" |


### PR DESCRIPTION
Hi Olmo,

In these commits, **Manual** refresh mode feature added to **UserQuery** (similar functionality was added to UserQueryPart as avoidAutoRefresh, but it was working only on dashboard as it was implemented by prop). Now if an UserQuery with RefreshMode = Manual has been selected, user will need to click Search button (or press Enter key on any filter inputs) to apply her/his latest find options (Filters+orderBy etc). This is a useful feature for heavy queries lets to avoid executing several costly queries on server once each change made to find options.

Auto refresh mode has been kept as default on creating new UserQuery unless currently a manual refresh UserQuery is selected on the search control. 

SC/SCL updated by adding corresponding state and defaultRefreshMode as prop. If header not shown a Search button will be added on the bottom of pinned filters in manual refresh mode. (it may need proper css for better adjustment above table or you may see to move it to the right of last pinned filter)

As an UX improvement with setting Search color to Red, user is informed that (s)he made some changes in findOption are pending for apply on next do Search.

As pagination mode All is very similar to manual RefreshMode in terms of performance consideration, to make both behavior consistent, with these changes, user will **always** need to do a search for pagination mode All (currently in some situations search is executed automatically)

BR,