### PR TITLE
Fix for new projects in AlertEntity

### DIFF
--- a/Signum.Entities.Extensions/Alerts/Alert.cs
+++ b/Signum.Entities.Extensions/Alerts/Alert.cs
@@ -24,7 +24,7 @@ namespace Signum.Entities.Alerts
 
 
         [AutoExpressionField]
-        public string Title => As.Expression(() => TitleField! ?? AlertType!.NiceToString()); //Replaced in Logic
+        public string Title => As.Expression(() => TitleField! ?? (AlertType != null ? AlertType.NiceToString() : CreationDate.ToString())); //Replaced in Logic
 
         [StringLengthValidator(Max = 100)]
         public string? TitleField { get; set; }
@@ -54,7 +54,7 @@ namespace Signum.Entities.Alerts
 
         [AutoExpressionField]
         public override string ToString() => As.Expression(() => Title);
-       
+
 
         [AutoExpressionField]
         public bool Attended => As.Expression(() => AttendedDate.HasValue);
@@ -76,7 +76,7 @@ namespace Signum.Entities.Alerts
 
         protected override string? PropertyValidation(PropertyInfo pi)
         {
-            if(pi.Name == nameof(TitleField) && TitleField == null && AlertType == null)
+            if (pi.Name == nameof(TitleField) && TitleField == null && AlertType == null)
                 return ValidationMessage._0IsNotSet.NiceToString(pi.NiceName());
 
             return base.PropertyValidation(pi);


### PR DESCRIPTION
Fixed alertType in AlertEntity null exception if your project is new and no have types of alerts. If is possible to create a alert without type because alert type is nullable, why is required for compose the title?

![image](https://user-images.githubusercontent.com/53967797/132051093-65ab4eb3-5f28-436a-8087-26b2998c3861.png)
