### PR TITLE
split and clarify Precision-Size and let Update/Insert into SQL Server Always Encrypted columns work

### DIFF
--- a/Signum.Engine/CodeGeneration/EntityCodeGenerator.cs
+++ b/Signum.Engine/CodeGeneration/EntityCodeGenerator.cs
@@ -763,10 +763,17 @@ namespace Signum.Engine.CodeGeneration
             var defaultSize = CurrentSchema.Settings.GetSqlSize(null, null, pair.DbType);
             if (defaultSize != null)
             {
-                if (!(defaultSize == col.Precision || defaultSize == col.Length || defaultSize == int.MaxValue && col.Length == -1))
+                if (!(defaultSize == col.Length || defaultSize == int.MaxValue && col.Length == -1))
                     parts.Add("Size = " + (col.Length == -1 ? "int.MaxValue" :
                                         col.Length != 0 ? col.Length.ToString() :
                                         col.Precision != 0 ? col.Precision.ToString() : "0"));
+            }
+
+            var defaultPrecision = CurrentSchema.Settings.GetSqlPrecision(null, null, pair.DbType);
+            if (defaultPrecision != null)
+            {
+                if (defaultPrecision != col.Precision)
+                    parts.Add("Precision = " + (col.Precision != 0 ? col.Precision.ToString() : "0"));
             }
 
             var defaultScale = CurrentSchema.Settings.GetSqlScale(null, null, col.DbType);

--- a/Signum.Engine/Connection/Connector.cs
+++ b/Signum.Engine/Connection/Connector.cs
@@ -181,7 +181,7 @@ namespace Signum.Engine
         }
 
         public abstract DbParameter CreateParameter(string parameterName, AbstractDbType dbType, string? udtTypeName, bool nullable, object? value);
-        public abstract MemberInitExpression ParameterFactory(Expression parameterName, AbstractDbType dbType, string? udtTypeName, bool nullable, Expression value);
+        public abstract MemberInitExpression ParameterFactory(Expression parameterName, AbstractDbType dbType, int? size, byte? precision, byte? scale, string? udtTypeName, bool nullable, Expression value);
 
         protected static MethodInfo miAsserDateTime = ReflectionTools.GetMethodInfo(() => AssertDateTime(null));
         protected static DateTime? AssertDateTime(DateTime? dateTime)

--- a/Signum.Engine/Connection/PostgreSqlConnector.cs
+++ b/Signum.Engine/Connection/PostgreSqlConnector.cs
@@ -533,7 +533,7 @@ END; $$;");
             return result;
         }
 
-        public override MemberInitExpression ParameterFactory(Expression parameterName, AbstractDbType dbType, string? udtTypeName, bool nullable, Expression value)
+        public override MemberInitExpression ParameterFactory(Expression parameterName, AbstractDbType dbType, int? size, byte? precision, byte? scale, string? udtTypeName, bool nullable, Expression value)
         {
             Expression valueExpr = Expression.Convert(
               !dbType.IsDate() ? value :
@@ -555,6 +555,15 @@ END; $$;");
                 Expression.Bind(typeof(NpgsqlParameter).GetProperty(nameof(NpgsqlParameter.IsNullable))!, Expression.Constant(nullable)),
                 Expression.Bind(typeof(NpgsqlParameter).GetProperty(nameof(NpgsqlParameter.NpgsqlDbType))!, Expression.Constant(dbType.PostgreSql)),
             };
+
+            if (size != null)
+                mb.Add(Expression.Bind(typeof(NpgsqlParameter).GetProperty(nameof(NpgsqlParameter.Size))!, Expression.Constant(size)));
+
+            if (precision != null)
+                mb.Add(Expression.Bind(typeof(NpgsqlParameter).GetProperty(nameof(NpgsqlParameter.Precision))!, Expression.Constant(precision)));
+
+            if (scale != null)
+                mb.Add(Expression.Bind(typeof(NpgsqlParameter).GetProperty(nameof(NpgsqlParameter.Scale))!, Expression.Constant(scale)));
 
             if (udtTypeName != null)
                 mb.Add(Expression.Bind(typeof(NpgsqlParameter).GetProperty(nameof(NpgsqlParameter.DataTypeName))!, Expression.Constant(udtTypeName)));

--- a/Signum.Engine/Connection/SqlServerConnector.cs
+++ b/Signum.Engine/Connection/SqlServerConnector.cs
@@ -552,7 +552,7 @@ namespace Signum.Engine
             return result;
         }
 
-        public override MemberInitExpression ParameterFactory(Expression parameterName, AbstractDbType dbType, string? udtTypeName, bool nullable, Expression value)
+        public override MemberInitExpression ParameterFactory(Expression parameterName, AbstractDbType dbType, int? size, byte? precision, byte? scale, string? udtTypeName, bool nullable, Expression value)
         {
             Expression valueExpr = Expression.Convert(
                 !dbType.IsDate() ? value: 
@@ -571,12 +571,21 @@ namespace Signum.Engine
 
             List<MemberBinding> mb = new()
             {
-                Expression.Bind(typeof(SqlParameter).GetProperty("IsNullable")!, Expression.Constant(nullable)),
-                Expression.Bind(typeof(SqlParameter).GetProperty("SqlDbType")!, Expression.Constant(dbType.SqlServer)),
+                Expression.Bind(typeof(SqlParameter).GetProperty(nameof(SqlParameter.IsNullable))!, Expression.Constant(nullable)),
+                Expression.Bind(typeof(SqlParameter).GetProperty(nameof(SqlParameter.SqlDbType))!, Expression.Constant(dbType.SqlServer)),
             };
 
+            if (size != null)
+                mb.Add(Expression.Bind(typeof(SqlParameter).GetProperty(nameof(SqlParameter.Size))!, Expression.Constant(size)));
+
+            if (precision != null)
+                mb.Add(Expression.Bind(typeof(SqlParameter).GetProperty(nameof(SqlParameter.Precision))!, Expression.Constant(precision)));
+
+            if (scale != null)
+                mb.Add(Expression.Bind(typeof(SqlParameter).GetProperty(nameof(SqlParameter.Scale))!, Expression.Constant(scale)));
+
             if (udtTypeName != null)
-                mb.Add(Expression.Bind(typeof(SqlParameter).GetProperty("UdtTypeName")!, Expression.Constant(udtTypeName)));
+                mb.Add(Expression.Bind(typeof(SqlParameter).GetProperty(nameof(SqlParameter.UdtTypeName))!, Expression.Constant(udtTypeName)));
 
             return Expression.MemberInit(newExpr, mb);
         }

--- a/Signum.Engine/Engine/SchemaSynchronizer.cs
+++ b/Signum.Engine/Engine/SchemaSynchronizer.cs
@@ -1148,12 +1148,12 @@ EXEC(@{1})".FormatWith(databaseName.Name, variableName));
 
         public bool SizeEquals(IColumn other)
         {
-            return (other.Size == null || other.Size.Value == Precision || other.Size.Value == Length || other.Size.Value == int.MaxValue && Length == -1);
+            return (other.DbType.IsDecimal() || other.Size == null || other.Size.Value == Precision || other.Size.Value == Length || other.Size.Value == int.MaxValue && Length == -1);
         }
 
         public bool PrecisionEquals(IColumn other)
         {
-            return (other.Precision == null || other.Precision == 0 || other.Precision.Value == Precision);
+            return (!other.DbType.IsDecimal() || other.Precision == null || other.Precision == 0 || other.Precision.Value == Precision);
         }
 
         public bool DefaultEquals(IColumn other)

--- a/Signum.Engine/Engine/SchemaSynchronizer.cs
+++ b/Signum.Engine/Engine/SchemaSynchronizer.cs
@@ -1129,6 +1129,7 @@ EXEC(@{1})".FormatWith(databaseName.Name, variableName));
                 && StringComparer.InvariantCultureIgnoreCase.Equals(UserTypeName, other.UserDefinedTypeName)
                 && Nullable == (other.Nullable.ToBool())
                 && SizeEquals(other)
+                && PrecisionEquals(other)
                 && ScaleEquals(other)
                 && (ignoreIdentity || Identity == other.Identity)
                 && (ignorePrimaryKey || PrimaryKey == other.PrimaryKey)
@@ -1148,6 +1149,11 @@ EXEC(@{1})".FormatWith(databaseName.Name, variableName));
         public bool SizeEquals(IColumn other)
         {
             return (other.Size == null || other.Size.Value == Precision || other.Size.Value == Length || other.Size.Value == int.MaxValue && Length == -1);
+        }
+
+        public bool PrecisionEquals(IColumn other)
+        {
+            return (other.Precision == null || other.Precision == 0 || other.Precision.Value == Precision);
         }
 
         public bool DefaultEquals(IColumn other)

--- a/Signum.Engine/Engine/SqlPreCommand.cs
+++ b/Signum.Engine/Engine/SqlPreCommand.cs
@@ -346,7 +346,8 @@ namespace Signum.Engine
             var pars = this.Parameters.EmptyIfNull();
             var sqlBuilder = Connector.Current.SqlBuilder;
 
-            var parameterVars = pars.ToString(p => $"{p.ParameterName} {(p is SqlParameter sp ? sp.SqlDbType.ToString() : ((NpgsqlParameter)p).NpgsqlDbType.ToString())}{sqlBuilder.GetSizeScale(p.Size.DefaultToNull(), p.Scale.DefaultToNull())}", ", ");
+            var parameterVars = pars.ToString(p => 
+                $"{p.ParameterName} {(p is SqlParameter sp ? sp.SqlDbType.ToString() : ((NpgsqlParameter)p).NpgsqlDbType.ToString())}{sqlBuilder.GetSizePrecisionScale(p.Size.DefaultToNull(), p.Precision.DefaultToNull(), p.Scale.DefaultToNull())}", ", ");
             var parameterValues = pars.ToString(p => p.ParameterName + " = " + Encode(p.Value, simple: true), ",\r\n");
 
             return @$"EXEC sp_executesql N'{this.Sql.Replace("'", "''")}', 

--- a/Signum.Engine/Engine/SqlPreCommand.cs
+++ b/Signum.Engine/Engine/SqlPreCommand.cs
@@ -346,8 +346,10 @@ namespace Signum.Engine
             var pars = this.Parameters.EmptyIfNull();
             var sqlBuilder = Connector.Current.SqlBuilder;
 
-            var parameterVars = pars.ToString(p => 
-                $"{p.ParameterName} {(p is SqlParameter sp ? sp.SqlDbType.ToString() : ((NpgsqlParameter)p).NpgsqlDbType.ToString())}{sqlBuilder.GetSizePrecisionScale(p.Size.DefaultToNull(), p.Precision.DefaultToNull(), p.Scale.DefaultToNull())}", ", ");
+            var parameterVars = pars.ToString(p => "{0} {1}{2}".FormatWith(
+                p.ParameterName,
+                p is SqlParameter sp ? sp.SqlDbType.ToString() : ((NpgsqlParameter)p).NpgsqlDbType.ToString(),
+                sqlBuilder.GetSizePrecisionScale(p.Size.DefaultToNull(), p.Precision.DefaultToNull(), p.Scale.DefaultToNull(), p.DbType == System.Data.DbType.Decimal)), ", ");
             var parameterValues = pars.ToString(p => p.ParameterName + " = " + Encode(p.Value, simple: true), ",\r\n");
 
             return @$"EXEC sp_executesql N'{this.Sql.Replace("'", "''")}', 

--- a/Signum.Engine/Schema/Schema.Basics.cs
+++ b/Signum.Engine/Schema/Schema.Basics.cs
@@ -115,7 +115,8 @@ namespace Signum.Engine.Maps
             public bool Identity => false;
             public string? Default { get; set; }
             public int? Size => null;
-            public int? Scale => null;
+            public byte? Precision => null;
+            public byte? Scale => null;
             public string? Collation => null;
             public Table? ReferenceTable => null;
             public bool AvoidForeignKey => false;
@@ -139,7 +140,8 @@ namespace Signum.Engine.Maps
             public bool Identity => false;
             public string? Default { get; set; }
             public int? Size => null;
-            public int? Scale => null;
+            public byte? Precision => null;
+            public byte? Scale => null;
             public string? Collation => null;
             public Table? ReferenceTable => null;
             public bool AvoidForeignKey => false;
@@ -473,7 +475,8 @@ namespace Signum.Engine.Maps
         bool Identity { get; }
         string? Default { get; }
         int? Size { get; }
-        int? Scale { get; }
+        byte? Precision { get; }
+        byte? Scale { get; }
         string? Collation { get; }
         Table? ReferenceTable { get; }
         bool AvoidForeignKey { get; }
@@ -526,7 +529,8 @@ namespace Signum.Engine.Maps
         public bool Identity { get; set; }
         bool IColumn.IdentityBehaviour { get { return table.IdentityBehaviour; } }
         public int? Size { get; set; }
-        int? IColumn.Scale { get { return null; } }
+        byte? IColumn.Precision { get { return null; } }
+        byte? IColumn.Scale { get { return null; } }
         public string? Collation { get; set; }
         Table? IColumn.ReferenceTable { get { return null; } }
         public Type Type { get; set; }
@@ -582,7 +586,8 @@ namespace Signum.Engine.Maps
         bool IColumn.IdentityBehaviour { get { return false; } }
         public int? Size { get; set; }
         public string? Collation { get; set; }
-        public int? Scale { get; set; }
+        public byte? Precision { get; set; }
+        public byte? Scale { get; set; }
         Table? IColumn.ReferenceTable { get { return null; } }
         public bool AvoidForeignKey { get { return false; } }
         public string? Default { get; set; }
@@ -595,11 +600,12 @@ namespace Signum.Engine.Maps
 
         public override string ToString()
         {
-            return "{0} {1} ({2},{3},{4})".FormatWith(
+            return "{0} {1} ({2},{3},{4},{5})".FormatWith(
                 Name,
                 DbType,
                 Nullable.ToBool() ? "Nullable" : "",
                 Size,
+                Precision,
                 Scale);
         }
 
@@ -647,7 +653,8 @@ namespace Signum.Engine.Maps
             bool IColumn.Identity { get { return false; } }
             bool IColumn.IdentityBehaviour { get { return false; } }
             int? IColumn.Size { get { return null; } }
-            int? IColumn.Scale { get { return null; } }
+            byte? IColumn.Precision { get { return null; } }
+            byte? IColumn.Scale { get { return null; } }
             string? IColumn.Collation { get { return null; } }
             public Table? ReferenceTable { get { return null; } }
             Type IColumn.Type { get { return typeof(bool); } }
@@ -914,7 +921,8 @@ namespace Signum.Engine.Maps
         bool IColumn.Identity { get { return false; } }
         bool IColumn.IdentityBehaviour { get { return false; } }
         int? IColumn.Size { get { return this.ReferenceTable.PrimaryKey.Size; } }
-        int? IColumn.Scale { get { return null; } }
+        byte? IColumn.Precision { get { return null; } }
+        byte? IColumn.Scale { get { return null; } }
         public Table ReferenceTable { get; set; }
         Table? IColumn.ReferenceTable => ReferenceTable;
         public AbstractDbType DbType { get { return ReferenceTable.PrimaryKey.DbType; } }
@@ -1163,7 +1171,8 @@ namespace Signum.Engine.Maps
         bool IColumn.Identity { get { return false; } }
         bool IColumn.IdentityBehaviour { get { return false; } }
         int? IColumn.Size { get { return null; } }
-        int? IColumn.Scale { get { return null; } }
+        byte? IColumn.Precision { get { return null; } }
+        byte? IColumn.Scale { get { return null; } }
         public Table ReferenceTable { get; private set; }
         Table? IColumn.ReferenceTable => ReferenceTable;
         public AbstractDbType DbType { get { return ReferenceTable.PrimaryKey.DbType; } }
@@ -1189,7 +1198,8 @@ namespace Signum.Engine.Maps
         bool IColumn.Identity { get { return false; } }
         bool IColumn.IdentityBehaviour { get { return false; } }
         public int? Size { get; set; }
-        int? IColumn.Scale { get { return null; } }
+        byte? IColumn.Precision { get { return null; } }
+        byte? IColumn.Scale { get { return null; } }
         public string? Collation { get; set; }
         public Table? ReferenceTable { get { return null; } }
         public AbstractDbType DbType => new AbstractDbType(SqlDbType.NVarChar, NpgsqlDbType.Varchar);
@@ -1283,7 +1293,8 @@ namespace Signum.Engine.Maps
             public bool Identity { get; set; }
             bool IColumn.IdentityBehaviour { get { return true; } }
             int? IColumn.Size { get { return null; } }
-            int? IColumn.Scale { get { return null; } }
+            byte? IColumn.Precision { get { return null; } }
+            byte? IColumn.Scale { get { return null; } }
             Table? IColumn.ReferenceTable { get { return null; } }
             public Type Type { get; set; }
             public bool AvoidForeignKey { get { return false; } }

--- a/Signum.Engine/Schema/Schema.Save.cs
+++ b/Signum.Engine/Schema/Schema.Save.cs
@@ -591,13 +591,13 @@ SELECT {id} FROM rows;";
 
                     List<Expression> parameters = new List<Expression>
                     {
-                        pb.ParameterFactory(Trio.Concat(idParamName, paramSuffix), table.PrimaryKey.DbType, null, false,
+                        pb.ParameterFactory(Trio.Concat(idParamName, paramSuffix), table.PrimaryKey.DbType, null, null, null, null, false,
                         Expression.Field(Expression.Property(Expression.Field(paramIdent, fiId), "Value"), "Object"))
                     };
 
                     if (table.Ticks != null)
                     {
-                        parameters.Add(pb.ParameterFactory(Trio.Concat(oldTicksParamName, paramSuffix), table.Ticks.DbType, null, false, table.Ticks.ConvertTicks(paramOldTicks)));
+                        parameters.Add(pb.ParameterFactory(Trio.Concat(oldTicksParamName, paramSuffix), table.Ticks.DbType, null, null, null, null, false, table.Ticks.ConvertTicks(paramOldTicks)));
                     }
 
                     parameters.AddRange(trios.Select(a => (Expression)a.ParameterBuilder));
@@ -811,7 +811,9 @@ END $$;"); ;
             {
                 this.SourceColumn = column.Name;
                 this.ParameterName = Signum.Engine.ParameterBuilder.GetParameterName(column.Name);
-                this.ParameterBuilder = Connector.Current.ParameterBuilder.ParameterFactory(Concat(this.ParameterName, suffix), column.DbType, column.UserDefinedTypeName, column.Nullable.ToBool(), value);
+                this.ParameterBuilder = Connector.Current.ParameterBuilder.ParameterFactory(
+                    Concat(this.ParameterName, suffix), 
+                    column.DbType, column.Size, column.Precision, column.Scale, column.UserDefinedTypeName, column.Nullable.ToBool(), value);
             }
 
             public string SourceColumn;
@@ -1239,9 +1241,9 @@ END $$;"); ;
 
                 var parameters = trios.Select(a => a.ParameterBuilder).ToList();
 
-                parameters.Add(pb.ParameterFactory(Table.Trio.Concat(parentId, paramSuffix), this.BackReference.DbType, null, false,
+                parameters.Add(pb.ParameterFactory(Table.Trio.Concat(parentId, paramSuffix), this.BackReference.DbType, null, null, null, null, false,
                     Expression.Field(Expression.Property(Expression.Field(paramIdent, Table.fiId), "Value"), "Object")));
-                parameters.Add(pb.ParameterFactory(Table.Trio.Concat(rowId, paramSuffix), this.PrimaryKey.DbType, null, false,
+                parameters.Add(pb.ParameterFactory(Table.Trio.Concat(rowId, paramSuffix), this.PrimaryKey.DbType, null, null, null, null, false,
                     Expression.Field(paramRowId, "Object")));
 
                 var expr = Expression.Lambda<Action<Entity, PrimaryKey, T, int, Forbidden, string, List<DbParameter>>>(

--- a/Signum.Engine/Schema/SchemaBuilder/SchemaBuilder.cs
+++ b/Signum.Engine/Schema/SchemaBuilder/SchemaBuilder.cs
@@ -583,6 +583,7 @@ namespace Signum.Engine.Maps
                 UserDefinedTypeName = pair.UserDefinedTypeName,
                 Nullable = IsNullable.No,
                 Size = Settings.GetSqlSize(ticksAttr, null, pair.DbType),
+                Precision = Settings.GetSqlPrecision(ticksAttr, null, pair.DbType),
                 Scale = Settings.GetSqlScale(ticksAttr, null, pair.DbType),
                 Default = ticksAttr?.GetDefault(Settings.IsPostgres),
             };
@@ -603,6 +604,7 @@ namespace Signum.Engine.Maps
                 UserDefinedTypeName = pair.UserDefinedTypeName,
                 Nullable = Settings.GetIsNullable(route, forceNull),
                 Size = Settings.GetSqlSize(att, route, pair.DbType),
+                Precision = Settings.GetSqlPrecision(att, route, pair.DbType),
                 Scale = Settings.GetSqlScale(att, route, pair.DbType),
                 Default = att?.GetDefault(Settings.IsPostgres),
             }.Do(f => f.UniqueIndex = f.GenerateUniqueIndex(table, Settings.FieldAttribute<UniqueIndexAttribute>(route)));
@@ -721,6 +723,7 @@ namespace Signum.Engine.Maps
                     UserDefinedTypeName = pair.UserDefinedTypeName,
                     Nullable = IsNullable.No,
                     Size = Settings.GetSqlSize(orderAttr, null, pair.DbType),
+                    Precision = Settings.GetSqlPrecision(orderAttr, null, pair.DbType),
                     Scale = Settings.GetSqlScale(orderAttr, null, pair.DbType),
                 };
             }

--- a/Signum.Engine/Schema/SchemaBuilder/SchemaSettings.cs
+++ b/Signum.Engine/Schema/SchemaBuilder/SchemaSettings.cs
@@ -89,7 +89,7 @@ namespace Signum.Engine.Maps
             {SqlDbType.Binary, 8000},
             {SqlDbType.Char, 1},
             {SqlDbType.NChar, 1},
-            {SqlDbType.Decimal, 18},
+//            {SqlDbType.Decimal, 18},
         };
 
         readonly Dictionary<NpgsqlDbType, int> defaultSizePostgreSql = new Dictionary<NpgsqlDbType, int>()
@@ -97,7 +97,7 @@ namespace Signum.Engine.Maps
             {NpgsqlDbType.Varbit, 200},
             {NpgsqlDbType.Varchar, 200},
             {NpgsqlDbType.Char, 1},
-            {NpgsqlDbType.Numeric, 18},
+//            {NpgsqlDbType.Numeric, 18},
         };
 
         readonly Dictionary<SqlDbType, byte> defaultPrecisionSqlServer = new Dictionary<SqlDbType, byte>()

--- a/Signum.Engine/Schema/SchemaBuilder/SchemaSettings.cs
+++ b/Signum.Engine/Schema/SchemaBuilder/SchemaSettings.cs
@@ -100,12 +100,22 @@ namespace Signum.Engine.Maps
             {NpgsqlDbType.Numeric, 18},
         };
 
-        readonly Dictionary<SqlDbType, int> defaultScaleSqlServer = new Dictionary<SqlDbType, int>()
+        readonly Dictionary<SqlDbType, byte> defaultPrecisionSqlServer = new Dictionary<SqlDbType, byte>()
+        {
+            {SqlDbType.Decimal, 18},
+        };
+
+        readonly Dictionary<NpgsqlDbType, byte> defaultPrecisionPostgreSql = new Dictionary<NpgsqlDbType, byte>()
+        {
+            {NpgsqlDbType.Numeric, 18},
+        };
+
+        readonly Dictionary<SqlDbType, byte> defaultScaleSqlServer = new Dictionary<SqlDbType, byte>()
         {
             {SqlDbType.Decimal, 2},
         };
 
-        readonly Dictionary<NpgsqlDbType, int> defaultScalePostgreSql = new Dictionary<NpgsqlDbType, int>()
+        readonly Dictionary<NpgsqlDbType, byte> defaultScalePostgreSql = new Dictionary<NpgsqlDbType, byte>()
         {
             {NpgsqlDbType.Numeric, 2},
         };
@@ -345,7 +355,28 @@ namespace Signum.Engine.Maps
                 return defaultSizePostgreSql.TryGetS(dbType.PostgreSql);
         }
 
-        internal int? GetSqlScale(DbTypeAttribute? att, PropertyRoute? route, AbstractDbType dbType)
+        internal byte? GetSqlPrecision(DbTypeAttribute? att, PropertyRoute? route, AbstractDbType dbType)
+        {
+            if (this.IsPostgres && dbType.PostgreSql == NpgsqlDbType.Bytea)
+                return null;
+
+            if (att != null && att.HasPrecision)
+                return att.Precision;
+
+/*            if (route != null && route.Type == typeof(string))
+            {
+                var sla = ValidatorAttribute<StringLengthValidatorAttribute>(route);
+                if (sla != null)
+                    return sla.Max == -1 ? int.MaxValue : sla.Max;
+            }*/
+
+            if (!this.IsPostgres)
+                return defaultPrecisionSqlServer.TryGetS(dbType.SqlServer);
+            else
+                return defaultPrecisionPostgreSql.TryGetS(dbType.PostgreSql);
+        }
+
+        internal byte? GetSqlScale(DbTypeAttribute? att, PropertyRoute? route, AbstractDbType dbType)
         {
             bool isDecimal = dbType.IsDecimal();
             if (att != null && att.HasScale)

--- a/Signum.Engine/Signum.Engine.csproj
+++ b/Signum.Engine/Signum.Engine.csproj
@@ -15,7 +15,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.1" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.0" />
 		<PackageReference Include="Npgsql" Version="5.0.10" />
 		<PackageReference Include="Signum.Analyzer" Version="3.1.0" />
 		<PackageReference Include="Signum.MSBuildTask" Version="5.0.0" />

--- a/Signum.Entities/FieldAttributes.cs
+++ b/Signum.Entities/FieldAttributes.cs
@@ -281,10 +281,18 @@ sb.Schema.Settings.FieldAttributes(({route.RootType.TypeName()} a) => a.{route.P
             set { size = value; }
         }
 
+        byte? precision;
+        public bool HasPrecision => precision.HasValue;
+        public byte Precision
+        {
+            get { return precision!.Value; }
+            set { precision = value; }
+        }
 
-        int? scale;
+
+        byte? scale;
         public bool HasScale => scale.HasValue;
-        public int Scale
+        public byte Scale
         {
             get { return scale!.Value; }
             set { scale = value; }

--- a/Signum.Entities/ValidationAttributes.cs
+++ b/Signum.Entities/ValidationAttributes.cs
@@ -414,14 +414,14 @@ namespace Signum.Entities
 
     public class DecimalsValidatorAttribute : ValidatorAttribute
     {
-        public int DecimalPlaces { get; set; }
+        public byte DecimalPlaces { get; set; }
 
         public DecimalsValidatorAttribute()
         {
             DecimalPlaces = 2;
         }
 
-        public DecimalsValidatorAttribute(int decimalPlaces)
+        public DecimalsValidatorAttribute(byte decimalPlaces)
         {
             this.DecimalPlaces = decimalPlaces;
         }


### PR DESCRIPTION
Hi,

Started from an exception in Update/Insert into **SQL Server Always Encrypted** columns: "Operand type clash ...", eventually _Precision_ is split from _Size_ in DBType attribute.

In addition to fix that AE exception, now (Size/Precision/Scale) made more clear and adapted to SQLServer/PostgreSql conventions. For decimal fields you explicitly specify Precision instead of Size.

By these commits Precision and Scale values are dedicatedly applied to decimal and leaves Size for others, so Precision and Scale values in DBType attribute will be _ignored_ for non decimal fields as well as Size for decimal fields.

BR,
