### PR TITLE
Handle wrong AuthToken without throwing exception

### DIFF
--- a/Signum.React.Extensions/Authorization/AuthTokensServer.cs
+++ b/Signum.React.Extensions/Authorization/AuthTokensServer.cs
@@ -64,11 +64,11 @@ public static class AuthTokenServer
     {
         var authHeader = ctx.HttpContext.Request.Headers[AuthHeader].FirstOrDefault();
         if (authHeader == null || !AuthenticateHeader(authHeader))
-        {
             return null;
-        }
-
+        
         var token = DeserializeAuthHeaderToken(authHeader);
+        if (token.User == null)
+            return null;
 
         var c = Configuration();
 


### PR DESCRIPTION
Handle AuthTokens generated by previous versions of Signum Framework without throwing exception