### PR TITLE
Browser caching for FilePathEmbedded and FilePathEntity

### DIFF
--- a/Signum.Engine.Extensions/Files/FilePathLogic.cs
+++ b/Signum.Engine.Extensions/Files/FilePathLogic.cs
@@ -6,6 +6,9 @@ namespace Signum.Engine.Files;
 
 public static class FilePathLogic
 {
+
+    public static Func<IFilePath, int> MaxAge = (fp) => 30 * 24 * 60 * 60; //used to set HTTP Cache-Control max-age, one month as default
+
     public static void AssertStarted(SchemaBuilder sb)
     {
         sb.AssertDefined(ReflectionTools.GetMethodInfo(() => FilePathLogic.Start(null!)));

--- a/Signum.Engine/Operations/OperationLogic.cs
+++ b/Signum.Engine/Operations/OperationLogic.cs
@@ -277,7 +277,29 @@ Consider the following options:
     #region Events
 
     public static event SurroundOperationHandler? SurroundOperation;
+    public static event OperationHandlerArgs? OperationBeforeExecute;
+    public static event OperationHandlerArgs? OperationExecuted;
     public static event AllowOperationHandler? AllowOperation;
+    public static event ErrorOperationHandler? OperationException;
+
+    internal static void OnOperationExceptionHandlerArgs(OperationSymbol operation, IEntity entity, Exception exc,  object?[]? args)
+    {
+        if (OperationException != null)
+            OperationException(operation, entity, exc, args);
+    }
+
+    internal static void OnOperationBeforeExecuteHandlerArgs(OperationSymbol operation, IEntity entity, object?[]? args)
+    {
+        if (OperationBeforeExecute != null)
+            OperationBeforeExecute(operation, entity, args);
+    }
+
+    internal static void OnOperationExecutedHandlerArgs(OperationSymbol operation, IEntity entity, object?[]? args)
+    {
+        if (OperationExecuted != null)
+            OperationExecuted(operation, entity, args);
+    }
+
 
     internal static IDisposable? OnSuroundOperation(IOperation operation, OperationLogEntity log, IEntity? entity, object?[]? args)
     {
@@ -870,7 +892,8 @@ public interface IEntityOperation : IOperation
 
 public delegate IDisposable? SurroundOperationHandler(IOperation operation, OperationLogEntity log, Entity? entity, object?[]? args);
 public delegate void OperationHandler(IOperation operation, Entity entity);
-public delegate void ErrorOperationHandler(IOperation operation, Entity entity, Exception ex);
+public delegate void ErrorOperationHandler(OperationSymbol operation, IEntity entity, Exception ex , object?[]? args);
 public delegate bool AllowOperationHandler(OperationSymbol operationSymbol, Type entityType, bool inUserInterface);
+public delegate void OperationHandlerArgs(OperationSymbol operation, IEntity entity, object?[]? args);
 
 

--- a/Signum.React.Extensions/Files/FileDownloader.tsx
+++ b/Signum.React.Extensions/Files/FileDownloader.tsx
@@ -130,7 +130,7 @@ registerConfiguration(FileEntity, {
 });
 
 registerConfiguration(FilePathEntity, {
-  fileUrl: file => AppContext.toAbsoluteUrl("~/api/files/downloadFilePath/" + file.id),
+  fileUrl: file => AppContext.toAbsoluteUrl(`~/api/files/downloadFilePath/${file.id}?${QueryString.stringify({ hash: file.hash })}`),
   fileLiteUrl: file => AppContext.toAbsoluteUrl("~/api/files/downloadFilePath/" + file.id),
 });
 
@@ -140,7 +140,8 @@ registerConfiguration(FileEmbedded, {
 });
 
 registerConfiguration(FilePathEmbedded, {
-  fileUrl: file => AppContext.toAbsoluteUrl(`~/api/files/downloadEmbeddedFilePath/${file.rootType}/${file.entityId}?${QueryString.stringify({ route: file.propertyRoute, rowId: file.mListRowId })}`)
+  fileUrl: file => AppContext.toAbsoluteUrl(
+    `~/api/files/downloadEmbeddedFilePath/${file.rootType}/${file.entityId}?${QueryString.stringify({ route: file.propertyRoute, rowId: file.mListRowId, hash: file.hash })}`)
 });
 
 export function downloadFile(file: IFilePath & ModifiableEntity): Promise<Response> {

--- a/Signum.React.Extensions/Files/FileImage.tsx
+++ b/Signum.React.Extensions/Files/FileImage.tsx
@@ -9,6 +9,7 @@ import { useFetchInState } from '../../Signum.React/Scripts/Navigator';
 interface FileImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   file?: IFile & ModifiableEntity | Lite<IFile & Entity> | null;
   placeholderSrc?: string
+  ajaxOptions?: Services.AjaxOptionsOverride;
 }
 
 export function FileImage(p: FileImageProps) {
@@ -27,7 +28,7 @@ export function FileImage(p: FileImageProps) {
           configurations[file.EntityType].fileLiteUrl!(file) :
           configurations[file.Type].fileUrl!(file);
 
-      Services.ajaxGetRaw({ url: url })
+      Services.ajaxGetRaw({ url: url, ...p.ajaxOptions ?? { cache: 'default' as RequestCache } })
         .then(resp => resp.blob())
         .then(blob => setObjectUrl(URL.createObjectURL(blob)));
 

--- a/Signum.React.Extensions/Files/FileImageLine.tsx
+++ b/Signum.React.Extensions/Files/FileImageLine.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { TypeContext } from '@framework/TypeContext'
 import { getSymbol } from '@framework/Reflection'
 import { FormGroup } from '@framework/Lines/FormGroup'
+import * as Services from '@framework/Services'
 import { ModifiableEntity, Lite, Entity, isLite, isEntity } from '@framework/Signum.Entities'
 import { IFile, FileTypeSymbol } from './Signum.Entities.Files'
 import { EntityBaseProps, EntityBaseController } from '@framework/Lines/EntityBase'
@@ -24,6 +25,7 @@ export interface FileImageLineProps extends EntityBaseProps {
   configuration?: FileDownloaderConfiguration<IFile>;
   imageHtmlAttributes?: React.ImgHTMLAttributes<HTMLImageElement>;
   maxSizeInBytes?: number;
+  ajaxOptions?: Services.AjaxOptionsOverride;
 }
 
 

--- a/Signum.React.Extensions/Files/FilesController.cs
+++ b/Signum.React.Extensions/Files/FilesController.cs
@@ -27,6 +27,8 @@ public class FilesController : ControllerBase
     {
         var filePath = Database.Retrieve<FilePathEntity>(PrimaryKey.Parse(filePathId, typeof(FilePathEntity)));
 
+        Response.Headers.CacheControl = $"max-age={FilePathLogic.MaxAge(filePath)}, private";
+
         return GetFileStreamResult(filePath.OpenRead(), filePath.FileName);
     }
 
@@ -54,7 +56,7 @@ public class FilesController : ControllerBase
         if (fpe == null)
             return null;
 
-        Response.Headers.CacheControl = "max-age=31536000, private";
+        Response.Headers.CacheControl = $"max-age={FilePathLogic.MaxAge(fpe)}, private";
 
         return GetFileStreamResult(fpe.OpenRead(), fpe.FileName);
     }

--- a/Signum.React.Extensions/Files/FilesController.cs
+++ b/Signum.React.Extensions/Files/FilesController.cs
@@ -6,8 +6,6 @@ using Signum.Engine.Mailing;
 using Signum.Entities.Basics;
 using Signum.Utilities.Reflection;
 using System.Collections.Concurrent;
-using Microsoft.AspNetCore.Http;
-using System.Web;
 
 namespace Signum.React.Files;
 

--- a/Signum.React.Extensions/Files/FilesController.cs
+++ b/Signum.React.Extensions/Files/FilesController.cs
@@ -7,6 +7,7 @@ using Signum.Entities.Basics;
 using Signum.Utilities.Reflection;
 using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Http;
+using System.Web;
 
 namespace Signum.React.Files;
 
@@ -30,7 +31,7 @@ public class FilesController : ControllerBase
     }
 
     [HttpGet("api/files/downloadEmbeddedFilePath/{rootType}/{id}")]
-    public ActionResult? DownloadFilePathEmbedded(string rootType, string id, string route, string? rowId)
+    public FileStreamResult? DownloadFilePathEmbedded(string rootType, string id, string route, string? rowId)
     {
         var type = TypeLogic.GetType(rootType);
 
@@ -52,11 +53,8 @@ public class FilesController : ControllerBase
         var fpe = makeQuery(primaryKey, rowId);
         if (fpe == null)
             return null;
-        
-        Response.Headers.ETag = fpe.Hash;
 
-        if (Request.Headers.IfNoneMatch.HasItems() && fpe.Hash == Request.Headers.IfNoneMatch)
-            return this.StatusCode(StatusCodes.Status304NotModified);
+        Response.Headers.CacheControl = "max-age=31536000, private";
 
         return GetFileStreamResult(fpe.OpenRead(), fpe.FileName);
     }

--- a/Signum.React.Extensions/Files/FilesController.cs
+++ b/Signum.React.Extensions/Files/FilesController.cs
@@ -6,6 +6,7 @@ using Signum.Engine.Mailing;
 using Signum.Entities.Basics;
 using Signum.Utilities.Reflection;
 using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Http;
 
 namespace Signum.React.Files;
 
@@ -29,7 +30,7 @@ public class FilesController : ControllerBase
     }
 
     [HttpGet("api/files/downloadEmbeddedFilePath/{rootType}/{id}")]
-    public FileStreamResult? DownloadFilePathEmbedded(string rootType, string id, string route, string? rowId)
+    public ActionResult? DownloadFilePathEmbedded(string rootType, string id, string route, string? rowId)
     {
         var type = TypeLogic.GetType(rootType);
 
@@ -51,6 +52,11 @@ public class FilesController : ControllerBase
         var fpe = makeQuery(primaryKey, rowId);
         if (fpe == null)
             return null;
+        
+        Response.Headers.ETag = fpe.Hash;
+
+        if (Request.Headers.IfNoneMatch.HasItems() && fpe.Hash == Request.Headers.IfNoneMatch)
+            return this.StatusCode(StatusCodes.Status304NotModified);
 
         return GetFileStreamResult(fpe.OpenRead(), fpe.FileName);
     }

--- a/Signum.React.Extensions/Translation/TranslationController.cs
+++ b/Signum.React.Extensions/Translation/TranslationController.cs
@@ -152,7 +152,7 @@ public class TranslationController : ControllerBase
 
         var cultures = TranslationLogic.CurrentCultureInfos(defaultCulture);
         Dictionary<CultureInfo, LocalizedAssembly> reference = (from ci in cultures
-                                                                let la = DescriptionManager.GetLocalizedAssembly(ass, ci)
+                                                                let la = DescriptionManager.GetLocalizedAssembly(ass, ci,true)
                                                                 where la != null || ci == defaultCulture || ci == targetCulture
                                                                 select KeyValuePair.Create(ci, la ?? LocalizedAssembly.ImportXml(ass, ci, forceCreate: ci == defaultCulture || ci == targetCulture))).ToDictionary();
 

--- a/Signum.React/Scripts/Modals/MessageModal.tsx
+++ b/Signum.React/Scripts/Modals/MessageModal.tsx
@@ -31,6 +31,7 @@ interface MessageModalProps extends IModalProps<MessageModalResult | undefined> 
   customIcon?: IconProp;
   size?: BsSize;
   shouldSelect?: boolean;
+  dialogAdditionalClassName?: string;
 }
 
 export default function MessageModal(p: MessageModalProps) {
@@ -147,7 +148,7 @@ export default function MessageModal(p: MessageModalProps) {
 
   return (
     <Modal show={show} onExited={handleOnExited} backdrop={p.shouldSelect ? 'static' : undefined}
-      dialogClassName={classes("message-modal", p.size && "modal-" + p.size)}
+      dialogClassName={classes("message-modal", p.size && "modal-" + p.size, p.dialogAdditionalClassName)}
       onHide={handleCancelClicked} autoFocus={true}>
       <div className={classes("modal-header", dialogHeaderClass(p.style))}>
         {renderTitle()}
@@ -179,6 +180,7 @@ MessageModal.show = (options: MessageModalProps): Promise<MessageModalResult | u
       customIcon={options.customIcon}
       style={options.style}
       shouldSelect={options.shouldSelect}
+      dialogAdditionalClassName={options.dialogAdditionalClassName}
     />
   );
 }

--- a/Signum.React/Scripts/Services.ts
+++ b/Signum.React/Scripts/Services.ts
@@ -37,7 +37,7 @@ export function ajaxGetRaw(options: AjaxOptions): Promise<Response> {
 
   return wrapRequest(options, () => {
 
-    const cache = options.cache || "no-cache";
+    const cache = options.cache || 'no-store';
     const isIE11 = !!(window as any).MSInputMethodContext && !!(document as any).documentMode;
 
     const headers = {
@@ -54,7 +54,7 @@ export function ajaxGetRaw(options: AjaxOptions): Promise<Response> {
       headers: headers,
       mode: options.mode,
       credentials: options.credentials || "same-origin",
-      cache: options.cache || "no-cache",
+      cache: cache,
       signal: options.signal
     } as RequestInit);
   });

--- a/Signum.React/Scripts/Services.ts
+++ b/Signum.React/Scripts/Services.ts
@@ -18,6 +18,8 @@ export interface AjaxOptions {
   signal?: AbortSignal;
 }
 
+export interface AjaxOptionsOverride extends Omit<AjaxOptions, "url"> { };
+
 export function baseUrl(options: AjaxOptions): string {
   const baseUrl = window.__baseUrl;
 

--- a/Signum.Utilities/DescriptionManager.cs
+++ b/Signum.Utilities/DescriptionManager.cs
@@ -298,11 +298,11 @@ public static class DescriptionManager
         return null;
     }
 
-    public static LocalizedAssembly? GetLocalizedAssembly(Assembly assembly, CultureInfo cultureInfo)
+    public static LocalizedAssembly? GetLocalizedAssembly(Assembly assembly, CultureInfo cultureInfo, bool forceCreate= false)
     {
         return localizations
             .GetOrAdd(cultureInfo, ci => new ConcurrentDictionary<Assembly, LocalizedAssembly?>())
-            .GetOrAdd(assembly, (Assembly a) => LocalizedAssembly.ImportXml(assembly, cultureInfo, forceCreate: false));
+            .GetOrAdd(assembly, (Assembly a) => LocalizedAssembly.ImportXml(assembly, cultureInfo, forceCreate: forceCreate));
     }
 
     internal static DescriptionOptions? OnDefaultDescriptionOptions(Type type)


### PR DESCRIPTION
### Browser caching for FilePathEmbedded and FilePathEntity

At a glance, this server and client side change suite enables browser to cache `FilePathEmbedded/FilePathEntity` blob/file, that is downloaded by `FileImage` (or `FileImageLine`) from the server.

Thanks to the great guidance from @olmobrutall, it eventually is implemented with [cache busting pattern](https://www.keycdn.com/support/what-is-cache-busting).

The age is set to 1 month as default, but it can be customized for each instance of EFP with replacing your own `MaxAge` function.

Also using new prop `ajaxOptions` on `FileImage` and `FileImageLine`, [request cache option](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache) can be overridden.
