### PR TITLE
fix onVersionFilter against requests hitting browser cache

### DIFF
--- a/Signum.React/Facades/ReflectionServer.cs
+++ b/Signum.React/Facades/ReflectionServer.cs
@@ -199,7 +199,7 @@ public static class ReflectionServer
                           ToStringFunction = typeof(Symbol).IsAssignableFrom(type) ? null : LambdaToJavascriptConverter.ToJavascript(ExpressionCleaner.GetFieldExpansion(type, miToString)!, false),
                           QueryDefined = queries.QueryDefined(type),
                           Members = PropertyRoute.GenerateRoutes(type)
-                            .Where(pr => InTypeScript(pr) && !ReflectionServer.ExcludeTypes.Contains(pr.Type))
+                            .Where(pr => InTypeScript(pr) && !ReflectionServer.ExcludeTypes.Contains(pr.Type) && !ReflectionServer.ExcludeTypes.Contains(pr.RootType) && (pr.Type.IsGenericType ? !ReflectionServer.ExcludeTypes.Contains(pr.Type.GenericTypeArguments[0]) : true))
                             .Select(p =>
                             {
                                 var validators = Entities.Validator.TryGetPropertyValidator(p)?.Validators;

--- a/Signum.React/Scripts/Services.ts
+++ b/Signum.React/Scripts/Services.ts
@@ -1,5 +1,6 @@
 import { ModelState, isEntity, ModelEntity } from './Signum.Entities'
 import { GraphExplorer } from './Reflection'
+import luxon, { DateTime } from 'luxon';
 
 export interface AjaxOptions {
   url: string;
@@ -170,11 +171,13 @@ export module VersionFilter {
         latestVersion = ver;
         initialBuildTime = buildTime!;
       }
-
+     
       if (latestVersion != ver) {
-        latestVersion = ver;
-        if (versionHasChanged)
-          versionHasChanged();
+        if (buildTime && initialBuildTime && DateTime.fromISO(buildTime).diff(DateTime.fromISO(initialBuildTime)).toMillis() > 0) {
+          latestVersion = ver;
+          if (versionHasChanged)
+            versionHasChanged();
+        }
       }
     }
 


### PR DESCRIPTION

This fixes a false positive version change detection that happens when a request responded from the browser cache (Version changed alert is shown while actually version is not changed on the server).