### PR TITLE
Implemented password hash migration for local Signum users

### DIFF
--- a/Extensions/Signum.Authorization.ActiveDirectory/ActiveDirectoryAuthorizer.cs
+++ b/Extensions/Signum.Authorization.ActiveDirectory/ActiveDirectoryAuthorizer.cs
@@ -106,9 +106,9 @@ public class ActiveDirectoryAuthorizer : ICustomAuthorizer
 
     public virtual UserEntity Login(string userName, string password, out string authenticationType)
     {
-        var passwordHash = PasswordEncoding.EncodePassword(password);
-        if (AuthLogic.TryRetrieveUser(userName, passwordHash) != null)
-            return AuthLogic.Login(userName, passwordHash, out authenticationType); //Database is faster than Active Directory
+        var passwordHashes = PasswordEncoding.EncodePassword(userName, password);
+        if (AuthLogic.TryRetrieveUser(userName, passwordHashes) != null)
+            return AuthLogic.Login(userName, passwordHashes, out authenticationType); //Database is faster than Active Directory
 
         UserEntity? user = LoginWithActiveDirectoryRegistry(userName, password);
         if (user != null)
@@ -117,7 +117,7 @@ public class ActiveDirectoryAuthorizer : ICustomAuthorizer
             return user;
         }
 
-        return AuthLogic.Login(userName, PasswordEncoding.EncodePassword(password), out authenticationType);
+        return AuthLogic.Login(userName, PasswordEncoding.EncodePassword(userName, password), out authenticationType);
     }
 
     public virtual UserEntity? LoginWithActiveDirectoryRegistry(string userName, string password)

--- a/Extensions/Signum.Authorization.ResetPassword/ResetPasswordRequestLogic.cs
+++ b/Extensions/Signum.Authorization.ResetPassword/ResetPasswordRequestLogic.cs
@@ -81,7 +81,7 @@ public static class ResetPasswordRequestLogic
                         user.Execute(UserOperation.Reactivate);
                     }
                     
-                    user.PasswordHash = PasswordEncoding.EncodePassword(password);
+                    user.PasswordHash = PasswordEncoding.EncodePassword(user.UserName, password).Last();
                     user.LoginFailedCounter = 0;
                     using (AuthLogic.Disable())
                     {

--- a/Extensions/Signum.Authorization/AuthController.cs
+++ b/Extensions/Signum.Authorization/AuthController.cs
@@ -24,7 +24,7 @@ public class AuthController : ControllerBase
         try
         {
             if (AuthLogic.Authorizer == null)
-                user = AuthLogic.Login(data.userName, PasswordEncoding.EncodePassword(data.password), out authenticationType);
+                user = AuthLogic.Login(data.userName, PasswordEncoding.EncodePassword(data.userName, data.password), out authenticationType);
             else
                 user = AuthLogic.Authorizer.Login(data.userName, data.password, out authenticationType);
         }
@@ -120,11 +120,11 @@ public class AuthController : ControllerBase
         }
         else
         {
-            if (user.PasswordHash == null || !user.PasswordHash.SequenceEqual(PasswordEncoding.EncodePassword(request.oldPassword)))
+            if (user.PasswordHash == null || !PasswordEncoding.EncodePassword(user.UserName, request.oldPassword).Any(oldPasswordHash => oldPasswordHash.SequenceEqual(user.PasswordHash)))
                 return ModelError("oldPassword", LoginAuthMessage.InvalidPassword.NiceToString());
         }
 
-        user.PasswordHash = PasswordEncoding.EncodePassword(request.newPassword);
+        user.PasswordHash = PasswordEncoding.EncodePassword(user.UserName, request.newPassword).Last();
         using (AuthLogic.Disable())
         using (OperationLogic.AllowSave<UserEntity>())
         {

--- a/Extensions/Signum.Authorization/AuthLogic.cs
+++ b/Extensions/Signum.Authorization/AuthLogic.cs
@@ -370,11 +370,11 @@ public static class AuthLogic
         OnRulesChanged?.Invoke();
     }
 
-    public static UserEntity Login(string username, byte[] passwordHash, out string authenticationType)
+    public static UserEntity Login(string username, IList<byte[]> passwordHashes, out string authenticationType)
     {
         using (AuthLogic.Disable())
         {
-            UserEntity user = RetrieveUser(username, passwordHash);
+            UserEntity user = RetrieveUser(username, passwordHashes);
 
             OnUserLogingIn(user);
 
@@ -391,7 +391,7 @@ public static class AuthLogic
 
     public static Action<UserEntity>? OnDeactivateUser;
 
-    public static UserEntity RetrieveUser(string username, byte[] passwordHash)
+    public static UserEntity RetrieveUser(string username, IList<byte[]> passwordHashes)
     {
         using (AuthLogic.Disable())
         {
@@ -401,7 +401,7 @@ public static class AuthLogic
                 throw new IncorrectUsernameException(LoginAuthMessage.Username0IsNotValid.NiceToString().FormatWith(username));
 
 
-            if (user.PasswordHash == null || !user.PasswordHash.SequenceEqual(passwordHash))
+            if (user.PasswordHash == null || (!passwordHashes.Any(passwordHash => passwordHash.SequenceEqual(user.PasswordHash))))
             {
                 using (UserHolder.UserSession(SystemUser!))
                 {
@@ -433,11 +433,22 @@ public static class AuthLogic
                 }
             }
 
+            if (!user.PasswordHash.SequenceEqual(passwordHashes.Last()))
+            {
+                user.PasswordHash = passwordHashes.Last();
+
+                using (AuthLogic.Disable())
+                using (OperationLogic.AllowSave<UserEntity>())
+                {
+                    user.Save();
+                }
+            }
+
             return user;
         }
     }
 
-    public static UserEntity? TryRetrieveUser(string username, byte[] passwordHash)
+    public static UserEntity? TryRetrieveUser(string username, IList<byte[]> passwordHashes)
     {
         using (AuthLogic.Disable())
         {
@@ -445,7 +456,7 @@ public static class AuthLogic
             if (user == null)
                 return null;
 
-            if (user.PasswordHash == null || !user.PasswordHash.SequenceEqual(passwordHash))
+            if (user.PasswordHash == null || !passwordHashes.Any(passwordHash => passwordHash.SequenceEqual(user.PasswordHash)))
                 return null;
 
             return user;

--- a/Extensions/Signum.Authorization/AuthServer.cs
+++ b/Extensions/Signum.Authorization/AuthServer.cs
@@ -234,7 +234,7 @@ public static class AuthServer
                     if (error != null)
                         throw new ApplicationException(error);
 
-                    ((UserEntity)ctx.Entity).PasswordHash = PasswordEncoding.EncodePassword(password);
+                    ((UserEntity)ctx.Entity).PasswordHash = PasswordEncoding.EncodePassword(((UserEntity)ctx.Entity).UserName, password).Last();
                 }
             }
         });

--- a/Extensions/Signum.Caching/Broadcast/SimpleHttpBroadcast.cs
+++ b/Extensions/Signum.Caching/Broadcast/SimpleHttpBroadcast.cs
@@ -13,7 +13,7 @@ public class SimpleHttpBroadcast : IServerBroadcast
 
     public SimpleHttpBroadcast(string broadcastSecret, string broadcastUrls)
     {
-        this.bordcastSecretHash = Convert.ToBase64String(PasswordEncoding.EncodePassword(broadcastSecret));
+        this.bordcastSecretHash = Convert.ToBase64String(PasswordEncoding.EncodePassword("", broadcastSecret).Last());
         this.broadcastUrls = broadcastUrls
             .SplitNoEmpty(new char[] { ';', ',' } /*In theory ; and , are valid in a URL, but since we talk only domain names or IPs...*/)
             .Select(a => a.Trim())

--- a/Signum/Security/PasswordEncoding.cs
+++ b/Signum/Security/PasswordEncoding.cs
@@ -4,7 +4,7 @@ namespace Signum.Security;
 
 public static class PasswordEncoding
 {
-    public static Func<string, byte[]> EncodePassword = (originalPassword) => MD5Hash(originalPassword);
+    public static Func<string, string, IList<byte[]>> EncodePassword = (userName, originalPassword) => new List<byte[]> { MD5Hash(originalPassword) };
 
     public static byte[] MD5Hash(string saltedPassword)
     {


### PR DESCRIPTION
At first I extended PasswordEncoding.EncodePassword() to return an IList<byte[]> instead of byte[]. This way multiple password hashes based on different algorithms can be returned by a Signum application, of which the last should be the most secure.

Now AuthLogic.RetrieveUser() checks if any password hash matches to authorize and updates User.PasswordHash if it's not the latest hash. This is where the actual password hash migration takes place and the code is executed on every login.

I wanted to use a some salt. However, this would require more extensive changes. Therefore I have decided to pass the user name, which can be used to derive a salt from it using SHA256 for example. Of course this is not ideal and a best effort solution.

All other changes are just calls to PasswordEncoding.EncodePassword().