### PR TITLE
Possibility to control visibility or Readonliness of specific entity property

### DIFF
--- a/Signum.Engine/Linq/ExpressionVisitor/QueryBinder.cs
+++ b/Signum.Engine/Linq/ExpressionVisitor/QueryBinder.cs
@@ -2898,6 +2898,9 @@ internal class QueryBinder : ExpressionVisitor
 
         var result = currentSource.FirstOrDefault(s => //could be more than one on GroupBy aggregates
         {
+            if (s == null)
+                return false;
+
             if (external.IsEmpty())
                 return true;
 

--- a/Signum.Engine/Schema/FluentInclude.cs
+++ b/Signum.Engine/Schema/FluentInclude.cs
@@ -53,5 +53,11 @@ public class FluentInclude<T> where T : Entity
         return this;
     }
 
+    public FluentInclude<T> WithAdditionalField<M>(Expression<Func<T, M>> property, Func<bool> shouldSet, Expression<Func<T, PrimaryKey?, M>> expression)
+    {
+        this.SchemaBuilder.Schema.EntityEvents<T>().RegisterBinding(property, shouldSet, expression);
+        return this;
+    }
+
 }
 

--- a/Signum.Entities/DynamicQuery/Tokens/EntityPropertyToken.cs
+++ b/Signum.Entities/DynamicQuery/Tokens/EntityPropertyToken.cs
@@ -41,9 +41,17 @@ public class EntityPropertyToken : QueryToken
         get { return PropertyInfo.Name; }
     }
 
+    public static Dictionary<PropertyRoute, Func<BuildExpressionContext, Expression/* parent/base expression*/, Expression>> CustomPropertyExpression = new Dictionary<PropertyRoute, Func<BuildExpressionContext, Expression , Expression>>();
+
     protected override Expression BuildExpressionInternal(BuildExpressionContext context)
     {
+
         var baseExpression = parent.BuildExpression(context);
+
+        CustomPropertyExpression.TryGetValue(PropertyRoute, out var customExpression);
+
+        if (customExpression != null)
+            return customExpression(context, baseExpression);
 
         if (PropertyInfo.Name == nameof(Entity.Id) ||
             PropertyInfo.Name == nameof(Entity.ToStringProperty))

--- a/Signum.Entities/Validator.cs
+++ b/Signum.Entities/Validator.cs
@@ -152,6 +152,7 @@ public class PropertyValidator<T> : IPropertyValidator
 
     public Func<T, PropertyInfo, string?>? StaticPropertyValidation { get; set; }
 
+    public Func<T, PropertyInfo, bool?>? IsReadonly { get; set; }
 
     internal PropertyValidator(PropertyInfo pi)
     {
@@ -255,8 +256,18 @@ public class PropertyValidator<T> : IPropertyValidator
     }
 
 
-    public bool IsPropertyReadonly(ModifiableEntity modifiableEntity)
+    public bool IsPropertyReadonly(T modifiableEntity)
     {
+        if (IsReadonly != null)
+        {
+            foreach (var item in IsReadonly.GetInvocationListTyped())
+            {
+                var result = item(modifiableEntity, PropertyInfo);
+                if (result == true)
+                    return true;
+            }
+        }
+
         if (modifiableEntity.IsPropertyReadonly(this.PropertyInfo))
             return true;
 
@@ -274,4 +285,10 @@ public class PropertyValidator<T> : IPropertyValidator
 
         return false;
     }
+
+    public bool IsPropertyReadonly(ModifiableEntity modifiableEntity)
+    {
+        return IsPropertyReadonly((T)modifiableEntity);
+    }
+
 }

--- a/Signum.React.Extensions/Authorization/AuthServer.cs
+++ b/Signum.React.Extensions/Authorization/AuthServer.cs
@@ -130,7 +130,6 @@ public static class AuthServer
                 }
                 return mi;
             };
-
         }
 
         if (PropertyAuthLogic.IsStarted)
@@ -158,6 +157,8 @@ public static class AuthServer
 
                 return allowed == PropertyAllowed.Write ? null : "Not allowed to write property: " + pr.ToString();
             };
+
+            PropertyAuthLogic.GetPropertyConverters = (t) => SignumServer.WebEntityJsonConverterFactory.GetPropertyConverters(t);
         }
 
         if (OperationAuthLogic.IsStarted)

--- a/Signum.React.Extensions/Authorization/AuthServer.cs
+++ b/Signum.React.Extensions/Authorization/AuthServer.cs
@@ -22,7 +22,7 @@ public static class AuthServer
     public static Action<ActionContext, UserWithClaims> UserLoggingOut;
 
     
-    public static void Start(IApplicationBuilder app, Func<AuthTokenConfigurationEmbedded> tokenConfig, string hashableEncryptionKey)
+    public static void Start(Func<AuthTokenConfigurationEmbedded> tokenConfig, string hashableEncryptionKey)
     {
         SignumControllerFactory.RegisterArea(MethodInfo.GetCurrentMethod());
 


### PR DESCRIPTION
### Possibility to control visibility or readonliness of specific entity property

introducing WithAdditionalField and .WithSecuredProperty on FluentInclude