### PR TITLE
Fix StackOverflow Exception while exporting Workflow asset

### DIFF
--- a/Extensions/Signum.Workflow/ImportExport/WorkflowImportExport.cs
+++ b/Extensions/Signum.Workflow/ImportExport/WorkflowImportExport.cs
@@ -80,7 +80,7 @@ public class WorkflowImportExport
             a.CustomNextButton?.ToXml("CustomNextButton")!,
             string.IsNullOrEmpty(a.UserHelp) ? null! : new XElement("UserHelp", new XCData(a.UserHelp)),
             a.SubWorkflow == null ? null! : new XElement("SubWorkflow",
-                new XAttribute("Workflow", ctx.Include(a.SubWorkflow.Workflow)),
+                new XAttribute("Workflow", a.SubWorkflow.Workflow.Is(workflow) ? a.SubWorkflow.Workflow.Guid : ctx.Include(a.SubWorkflow.Workflow)),
                 new XElement("SubEntitiesEval", new XCData(a.SubWorkflow.SubEntitiesEval.Script))
             ),
             a.Script == null ? null! : new XElement("Script",
@@ -342,7 +342,7 @@ public class WorkflowImportExport
                     activity.UserHelp = xml.Element("UserHelp")?.Value;
                     activity.SubWorkflow = activity.SubWorkflow.CreateOrAssignEmbedded(xml.Element("SubWorkflow"), (swe, elem) =>
                     {
-                        swe.Workflow = (WorkflowEntity)ctx.GetEntity((Guid)elem.Attribute("Workflow")!);
+                        swe.Workflow = workflow.Guid == (Guid)elem.Attribute("Workflow")! ? workflow : (WorkflowEntity)ctx.GetEntity((Guid)elem.Attribute("Workflow")!);
                         swe.SubEntitiesEval = swe.SubEntitiesEval.CreateOrAssignEmbedded(elem.Element("SubEntitiesEval"), (se, x) =>
                         {
                             se.Script = x.Value;


### PR DESCRIPTION
When you need to export a workflow with a script/lane as the same workflow, it enters in a loop exporting the same Entity and generate a Stack Overflow.

This verify if the subworkflow is the same as main and use the same Guid, and don't export the Entity with `ctx.Include(a.SubWorkflow.Workflow).`

To replicate this error, in a live environment. Create a new Workflow and put a Activity of type CallWorkflow and put the same workflow. In the script paste this (replacing your entity to test):
`return new List<EntityTestWorkflow>
	{
    new EntityTestWorkflow()
	};`

Then save the workflow, And try to export. It give a loop exporting the same Activity every 5-10 stacks in the ToXml of WorkflowImportExport.

This fix the ToXml. 

Now the opposite. If you try to import the asset, got the same loop and got a stackoverflow.

In FromXml check if the entity of the workflow is the same as the main entity (Using the Guid from the Xml). If it use the same, got the same main entity instead of enter the  `(WorkflowEntity)ctx.GetEntity((Guid)elem.Attribute("Workflow")`

Tested and verified in a working test environment with the above test to replicate the error and a production server that we need to export a workflow with this type of Activity.

Pics from the test workflow
![image](https://github.com/user-attachments/assets/ca6b6386-854a-4615-83da-a0f8b4f79544)
![image](https://github.com/user-attachments/assets/0a5f5e00-213e-480f-9fef-766a7bbadd43)

