### PR TITLE
fix Import/Export Workflows

### DIFF
--- a/Extensions/Signum.Workflow/ImportExport/WorkflowImportExport.cs
+++ b/Extensions/Signum.Workflow/ImportExport/WorkflowImportExport.cs
@@ -80,7 +80,7 @@ public class WorkflowImportExport
             a.CustomNextButton?.ToXml("CustomNextButton")!,
             string.IsNullOrEmpty(a.UserHelp) ? null! : new XElement("UserHelp", new XCData(a.UserHelp)),
             a.SubWorkflow == null ? null! : new XElement("SubWorkflow",
-                new XAttribute("Workflow", ctx.Include(a.SubWorkflow.Workflow)),
+                new XAttribute("Workflow", a.SubWorkflow.Workflow.Is(workflow) ? a.SubWorkflow.Workflow.Guid : ctx.Include(a.SubWorkflow.Workflow)),
                 new XElement("SubEntitiesEval", new XCData(a.SubWorkflow.SubEntitiesEval.Script))
             ),
             a.Script == null ? null! : new XElement("Script",
@@ -342,7 +342,7 @@ public class WorkflowImportExport
                     activity.UserHelp = xml.Element("UserHelp")?.Value;
                     activity.SubWorkflow = activity.SubWorkflow.CreateOrAssignEmbedded(xml.Element("SubWorkflow"), (swe, elem) =>
                     {
-                        swe.Workflow = (WorkflowEntity)ctx.GetEntity((Guid)elem.Attribute("Workflow")!);
+                        swe.Workflow = workflow.Guid == (Guid)elem.Attribute("Workflow")! ? workflow : (WorkflowEntity)ctx.GetEntity((Guid)elem.Attribute("Workflow")!);
                         swe.SubEntitiesEval = swe.SubEntitiesEval.CreateOrAssignEmbedded(elem.Element("SubEntitiesEval"), (se, x) =>
                         {
                             se.Script = x.Value;


### PR DESCRIPTION
Fix for avoid StackOverflow while importing/exporting the Workflow while the workflow is the same and create itself one same workflow on the Activity

The fix check if the workflow is the same and use the main Guid and avoids to export the Entity/Workflow. In the import procedure, if the workflow to import is the same than the main, avoid the import and assign it.

To replicate this error:

Create a Simple Workflow's Entity with their Case Interface. Later create a new Workflow and put a Activity of type CallWorkflow and put the same workflow after you create it. In the script paste this (replacing your entity to test):
**_return new List<EntityTestWorkflow> { new EntityTestWorkflow() };_**

Export it. It give a loop exporting the same Activity every 5-10 stacks in the ToXml of WorkflowImportExport ending with a Stackoverflow.


![image](https://github.com/user-attachments/assets/8d53034a-2858-4d2c-977b-856f4b7bfd5e)
![image](https://github.com/user-attachments/assets/9069996e-509f-466d-86e5-7646e0088c81)


Pd. How i've commented in the another PR, i've got issues with my account and loose the fork and it remove the PR. Luckily i've got a copy of the message/images