### PR TITLE
fix: correct Sucesfully to Successfully typo in AuthLogic.cs

### DIFF
--- a/Extensions/Signum.Authorization/AuthLogic.cs
+++ b/Extensions/Signum.Authorization/AuthLogic.cs
@@ -946,7 +946,7 @@ public static class AuthLogic
         {
             var doc = ExportRules();
             doc.Save(fileName);
-            Console.WriteLine("Sucesfully exported to {0}".FormatWith(fileName));
+            Console.WriteLine("Successfully exported to {0}".FormatWith(fileName));
 
             var info = new DirectoryInfo("../../../");
 


### PR DESCRIPTION
## Summary
Corrects a typo in a user-facing `Console.WriteLine` message in `Extensions/Signum.Authorization/AuthLogic.cs` line 949.

## Fix
```diff
- Console.WriteLine("Sucesfully exported to {0}".FormatWith(fileName));
+ Console.WriteLine("Successfully exported to {0}".FormatWith(fileName));
```

## Context
When an admin exports authorization rules using this tool, the console output displays "Sucesfully exported" instead of the correct spelling "Successfully exported".

## Testing
This is a one-character typo fix in a user-facing string. The change is straightforward and requires no additional testing.

---
Submitted via automated PR攻关 agent.